### PR TITLE
Fix ReplayBuffer missing argument

### DIFF
--- a/duckietown_rl/scripts/train_cnn.py
+++ b/duckietown_rl/scripts/train_cnn.py
@@ -50,7 +50,7 @@ max_action = float(env.action_space.high[0])
 # Initialize policy
 policy = DDPG(state_dim, action_dim, max_action, net_type="cnn")
 
-replay_buffer = ReplayBuffer()
+replay_buffer = ReplayBuffer(args.replay_buffer_max_size)
 
 # Evaluate untrained policy
 evaluations= [evaluate_policy(env, policy)]


### PR DESCRIPTION
Issue with call to utils.ReplayBuffer() in scripts/train_cnn.py, which misses the max_size argument.

Thanks to @bramtoula for pointing this out.